### PR TITLE
Fix loading of LDIF directory

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@
 # Please keep the list sorted.
 
 Kopano b.v.
+ownCloud GmbH

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,4 +14,5 @@
 # Please keep the list sorted.
 
 Felix Bartels <f.bartels@kopano.com>
+Ralf Haferkamp <rhaferkamp@owncloud.com>
 Simon Eisenmann <s.eisenmann@kopano.com> <simon@longsleep.org>

--- a/server/handler/ldif/ldif.go
+++ b/server/handler/ldif/ldif.go
@@ -80,6 +80,7 @@ func parseLDIFDirectory(pn string, options *Options) (*ldif.LDIF, []error, error
 					return fmt.Errorf("template read error: %w", copyErr)
 				}
 			}
+			buf.WriteString("\n\n")
 			return nil
 		}()
 		if err != nil {


### PR DESCRIPTION
When loading multiple LDIF files from a directory insert linebreaks
after reading each file to separate the Entries correctly.