### PR TITLE
Introduce BoltDB LDAP handler

### DIFF
--- a/cmd/idmd/boltdb/boltdb.go
+++ b/cmd/idmd/boltdb/boltdb.go
@@ -15,10 +15,10 @@ import (
 )
 
 var (
-	BoltDBFile string
-	LDAPBaseDN string
-	LogLevel   string
-	InputFile  string
+	BoltDBFile = ""
+	LDAPBaseDN = ""
+	LogLevel   = "info"
+	InputFile  = ""
 )
 
 func CommandBoltDB() *cobra.Command {

--- a/cmd/idmd/boltdb/boltdb.go
+++ b/cmd/idmd/boltdb/boltdb.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/libregraph/idm/cmd/idmd/boltdb/export"
 	"github.com/libregraph/idm/cmd/idmd/boltdb/load"
 )
 
@@ -53,7 +54,25 @@ need to	be correctly sorted, so that parent entries are created before their chi
 		os.Exit(1)
 	}
 
+	exportLDIFCmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export an existing database to LDIF",
+		Long:  `The export command exports LDAP entries in an existing BoltDB to stdout in LDIF.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := exportLDIF(cmd, args); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+	exportLDIFCmd.Flags().StringVar(&LDAPBaseDN, "ldap-base-dn", LDAPBaseDN, "BaseDN for LDAP requests")
+	if err := exportLDIFCmd.MarkFlagRequired("ldap-base-dn"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
 	boltdbCmd.AddCommand(loadLDIFCmd)
+	boltdbCmd.AddCommand(exportLDIFCmd)
 
 	return boltdbCmd
 }
@@ -64,4 +83,13 @@ func loadLDIF(_ *cobra.Command, _ []string) error {
 		return err
 	}
 	return loader.Load(InputFile)
+}
+
+func exportLDIF(_ *cobra.Command, _ []string) error {
+	exporter, err := export.NewLDIFExporter(LogLevel, BoltDBFile, LDAPBaseDN)
+
+	if err != nil {
+		return err
+	}
+	return exporter.Export()
 }

--- a/cmd/idmd/boltdb/boltdb.go
+++ b/cmd/idmd/boltdb/boltdb.go
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2021 The LibreGraph Authors.
+ */
+
+package boltdb
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/libregraph/idm/cmd/idmd/boltdb/load"
+)
+
+var (
+	BoltDBFile string
+	LDAPBaseDN string
+	LogLevel   string
+	InputFile  string
+)
+
+func CommandBoltDB() *cobra.Command {
+	boltdbCmd := &cobra.Command{
+		Use:   "boltdb [...args]",
+		Short: "Utility commands related to the BoltDB Database Handler",
+	}
+
+	boltdbCmd.PersistentFlags().StringVar(&LogLevel, "log-level", LogLevel, "Log level (one of panic, fatal, error, warn, info or debug)")
+	boltdbCmd.PersistentFlags().StringVar(&BoltDBFile, "boltdb-file", BoltDBFile, "Filename of the database for the BoltDB Handler")
+	loadLDIFCmd := &cobra.Command{
+		Use:   "load",
+		Short: "Initialize a database from an LDIF file",
+		Long: `The load command imports LDAP entries from an LDIF file and stores them into a BoltDB database.
+If the database already exists it will be overwritten. The Entries in the LDIF file
+need to	be correctly sorted, so that parent entries are created before their children.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := loadLDIF(cmd, args); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+	loadLDIFCmd.Flags().StringVar(&InputFile, "input-file", InputFile, "Filename of LDIF to read into database")
+	loadLDIFCmd.Flags().StringVar(&LDAPBaseDN, "ldap-base-dn", LDAPBaseDN, "BaseDN for LDAP requests")
+	if err := loadLDIFCmd.MarkFlagRequired("input-file"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if err := loadLDIFCmd.MarkFlagRequired("ldap-base-dn"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	boltdbCmd.AddCommand(loadLDIFCmd)
+
+	return boltdbCmd
+}
+
+func loadLDIF(_ *cobra.Command, _ []string) error {
+	loader, err := load.NewLDIFLoader(LogLevel, BoltDBFile, LDAPBaseDN)
+	if err != nil {
+		return err
+	}
+	return loader.Load(InputFile)
+}

--- a/cmd/idmd/boltdb/export/export.go
+++ b/cmd/idmd/boltdb/export/export.go
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2021 The LibreGraph Authors.
+ */
+
+package export
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/go-ldap/ldif"
+	"github.com/sirupsen/logrus"
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/libregraph/idm/pkg/ldbbolt"
+)
+
+type LDIFExporter struct {
+	logger logrus.FieldLogger
+	dbFile string
+	baseDN string
+}
+
+func NewLDIFExporter(logLevel, dbFile, base string) (*LDIFExporter, error) {
+	level, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &LDIFExporter{
+		logger: &logrus.Logger{
+			Out:       os.Stderr,
+			Formatter: &logrus.TextFormatter{},
+			Level:     level,
+		},
+		dbFile: dbFile,
+		baseDN: base,
+	}
+	return res, nil
+}
+
+func (l *LDIFExporter) Export() error {
+	bdb := &ldbbolt.LdbBolt{}
+
+	if err := bdb.Configure(l.logger, l.baseDN, l.dbFile, &bolt.Options{ReadOnly: true}); err != nil {
+		return err
+	}
+	defer bdb.Close()
+
+	if err := bdb.Initialize(); err != nil {
+		return err
+	}
+
+	entries, err := bdb.Search(l.baseDN, ldap.ScopeWholeSubtree)
+	if err != nil {
+		l.logger.Error(err)
+		return err
+	}
+
+	ld, err := ldif.ToLDIF(entries)
+	if err != nil {
+		l.logger.Error(err)
+		return err
+	}
+
+	output, err := ldif.Marshal(ld)
+	if err != nil {
+		l.logger.Error(err)
+		return err
+	}
+
+	fmt.Print(output)
+	return nil
+}

--- a/cmd/idmd/boltdb/load/load.go
+++ b/cmd/idmd/boltdb/load/load.go
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2021 The LibreGraph Authors.
+ */
+
+package load
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-ldap/ldif"
+	"github.com/sirupsen/logrus"
+
+	"github.com/libregraph/idm/pkg/ldbbolt"
+)
+
+type LDIFLoader struct {
+	logger logrus.FieldLogger
+	dbFile string
+	baseDN string
+}
+
+func NewLDIFLoader(logLevel, dbFile, base string) (*LDIFLoader, error) {
+	level, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &LDIFLoader{
+		logger: &logrus.Logger{
+			Out:       os.Stderr,
+			Formatter: &logrus.TextFormatter{},
+			Level:     level,
+		},
+		dbFile: dbFile,
+		baseDN: base,
+	}
+	return res, nil
+}
+
+func (l *LDIFLoader) Load(ldifFile string) error {
+	bdb := &ldbbolt.LdbBolt{}
+
+	if err := bdb.Configure(l.logger, l.baseDN, l.dbFile); err != nil {
+		return err
+	}
+	defer bdb.Close()
+
+	if err := bdb.Initialize(); err != nil {
+		return err
+	}
+
+	f, err := os.Open(ldifFile)
+	if err != nil {
+		return fmt.Errorf("error opening file '%s': %w", ldifFile, err)
+	}
+	defer f.Close()
+	lf := &ldif.LDIF{}
+	err = ldif.Unmarshal(f, lf)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range lf.AllEntries() {
+		l.logger.Debugf("Adding '%s'", entry.DN)
+		if err := bdb.EntryPut(entry); err != nil {
+			return fmt.Errorf("error adding Entry '%s': %w", entry.DN, err)
+		}
+	}
+	return nil
+}

--- a/cmd/idmd/boltdb/load/load.go
+++ b/cmd/idmd/boltdb/load/load.go
@@ -42,7 +42,7 @@ func NewLDIFLoader(logLevel, dbFile, base string) (*LDIFLoader, error) {
 func (l *LDIFLoader) Load(ldifFile string) error {
 	bdb := &ldbbolt.LdbBolt{}
 
-	if err := bdb.Configure(l.logger, l.baseDN, l.dbFile); err != nil {
+	if err := bdb.Configure(l.logger, l.baseDN, l.dbFile, nil); err != nil {
 		return err
 	}
 	defer bdb.Close()

--- a/cmd/idmd/main.go
+++ b/cmd/idmd/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/libregraph/idm/cmd"
+	"github.com/libregraph/idm/cmd/idmd/boltdb"
 	"github.com/libregraph/idm/cmd/idmd/gen"
 	"github.com/libregraph/idm/cmd/idmd/serve"
 )
@@ -19,7 +20,7 @@ func main() {
 
 	cmd.RootCmd.AddCommand(serve.CommandServe())
 	cmd.RootCmd.AddCommand(gen.CommandGen())
-
+	cmd.RootCmd.AddCommand(boltdb.CommandBoltDB())
 	if err := cmd.RootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)

--- a/cmd/idmd/serve/serve.go
+++ b/cmd/idmd/serve/serve.go
@@ -40,6 +40,7 @@ var (
 	DefaultLDAPBaseDN                  = ""
 	DefaultLDAPAllowLocalAnonymousBind = false
 
+	DefaultBoltDBFile = "idmbolt.db"
 	DefaultLDIFMain   = ""
 	DefaultLDIFConfig = ""
 
@@ -67,6 +68,10 @@ func setDefaults() {
 	DefaultLDIFMain = os.Getenv(withEnvBase("DEFAULT_LDIF_MAIN_PATH"))
 	DefaultLDIFConfig = os.Getenv(withEnvBase("DEFAULT_LDIF_CONFIG_PATH"))
 
+	envDefaultBoltDBFile := os.Getenv(withEnvBase("DEFAULT_BOLTDB_FILE"))
+	if envDefaultBoltDBFile != "" {
+		DefaultBoltDBFile = envDefaultBoltDBFile
+	}
 	envDefaultLDAPBaseDN := os.Getenv(withEnvBase("DEFAULT_LDAP_BASEDN"))
 	if envDefaultLDAPBaseDN != "" {
 		DefaultLDAPBaseDN = envDefaultLDAPBaseDN
@@ -151,6 +156,8 @@ func CommandServe() *cobra.Command {
 	serveCmd.Flags().StringVar(&DefaultLDAPBaseDN, "ldap-base-dn", DefaultLDAPBaseDN, "BaseDN for LDAP requests")
 	serveCmd.Flags().BoolVar(&DefaultLDAPAllowLocalAnonymousBind, "ldap-allow-local-anonymous", DefaultLDAPAllowLocalAnonymousBind, "Allow anonymous LDAP bind for all local LDAP clients")
 
+	serveCmd.Flags().StringVar(&DefaultBoltDBFile, "boltdb-file", DefaultBoltDBFile, "Filename of the database for the BoltDB Handler")
+
 	serveCmd.Flags().StringVar(&DefaultLDIFMain, "ldif-main", DefaultLDIFMain, "Path to a LDIF file or .d folder containing LDIF files")
 	serveCmd.Flags().StringVar(&DefaultLDIFConfig, "ldif-config", DefaultLDIFConfig, "Path to a LDIF file for entries used only for bind")
 
@@ -226,6 +233,8 @@ func (bs *bootstrap) configure(ctx context.Context, cmd *cobra.Command, args []s
 
 		LDIFDefaultCompany:    DefaultLDIFCompany,
 		LDIFDefaultMailDomain: DefaultLDIFMailDomain,
+
+		BoltDBFile: DefaultBoltDBFile,
 
 		OnReady: func(srv *server.Server) {
 			if DefaultSystemdNotify {

--- a/cmd/idmd/serve/serve.go
+++ b/cmd/idmd/serve/serve.go
@@ -29,6 +29,8 @@ var (
 	DefaultLogLevel      = "info"
 	DefaultSystemdNotify = false
 
+	DefaultLDAPHandler = "ldif"
+
 	DefaultLDAPListenAddr  = "127.0.0.1:10389"
 	DefaultLDAPSListenAddr = ""
 
@@ -139,6 +141,7 @@ func CommandServe() *cobra.Command {
 	serveCmd.Flags().StringVar(&DefaultLogLevel, "log-level", DefaultLogLevel, "Log level (one of panic, fatal, error, warn, info or debug)")
 	serveCmd.Flags().BoolVar(&DefaultSystemdNotify, "systemd-notify", DefaultSystemdNotify, "Enable systemd sd_notify callback")
 
+	serveCmd.Flags().StringVar(&DefaultLDAPHandler, "ldap-handler", DefaultLDAPHandler, "Name of handler to use, currently only	'ldif'")
 	serveCmd.Flags().StringVar(&DefaultLDAPListenAddr, "ldap-listen", DefaultLDAPListenAddr, "TCP listen address for LDAP requests")
 	serveCmd.Flags().StringVar(&DefaultLDAPSListenAddr, "ldaps-listen", DefaultLDAPSListenAddr, "TCP listen address for LDAPS requests")
 
@@ -206,6 +209,8 @@ func (bs *bootstrap) configure(ctx context.Context, cmd *cobra.Command, args []s
 
 	cfg := &server.Config{
 		Logger: logger,
+
+		LDAPHandler: DefaultLDAPHandler,
 
 		LDAPListenAddr:  DefaultLDAPListenAddr,
 		LDAPSListenAddr: DefaultLDAPSListenAddr,

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/test-go/testify v1.1.4 // indirect
 	github.com/trustelem/zxcvbn v1.0.1
+	go.etcd.io/bbolt v1.3.2
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
+	golang.org/x/text v0.3.3
 	stash.kopano.io/kgol/rndm v1.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/trustelem/zxcvbn v1.0.1 h1:mp4JFtzdDYGj9WYSD3KQSkwwUumWNFzXaAjckaTYpsc=
 github.com/trustelem/zxcvbn v1.0.1/go.mod h1:zonUyKeh7sw6psPf/e3DtRqkRyZvAbOfjNz/aO7YQ5s=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+go.etcd.io/bbolt v1.3.2 h1:Z/90sZLPOeCy2PwprqkFa25PdkusRzaj9P8zm/KNyvk=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -292,7 +293,9 @@ golang.org/x/term v0.0.0-20210317153231-de623e64d2a6 h1:EC6+IGYTjPpRfv9a2b/6Puw0
 golang.org/x/term v0.0.0-20210317153231-de623e64d2a6/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/pkg/ldbbolt/ldbbolt.go
+++ b/pkg/ldbbolt/ldbbolt.go
@@ -1,0 +1,258 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2021 The LibreGraph Authors.
+ */
+
+// Package ldbbolt provides the lower-level Database functions for managing LDAP Entries
+// in a	BoltDB database. Some implementation details:
+//
+// The database is currently separated in these three buckets
+//
+// - id2entry: This bucket contains the GOB encoded ldap.Entry instances keyed
+//             by a unique 64bit ID
+//
+// - dn2id: This bucket is used as an index to lookup the ID of an entry by its DN. The DN
+//          is used in an normalized (case-folded) form here.
+//
+// - id2children: This bucket uses the entry-ids as and index and the values contain a list
+//                of the entry ids of its direct childdren
+//
+// Additional buckets will likely be added in the future to create efficient search indexes
+package ldbbolt
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/gob"
+	"fmt"
+	"strings"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/sirupsen/logrus"
+	bolt "go.etcd.io/bbolt"
+	"golang.org/x/text/cases"
+)
+
+type LdbBolt struct {
+	logger logrus.FieldLogger
+	db     *bolt.DB
+	base   string
+}
+
+func (bdb *LdbBolt) Configure(logger logrus.FieldLogger, baseDN, dbfile string) error {
+	bdb.logger = logger
+	logger.Debugf("Open boltdb %s", dbfile)
+	db, err := bolt.Open(dbfile, 0o600, nil)
+	if err != nil {
+		bdb.logger.WithError(err).Error("Error opening database")
+		return err
+	}
+	bdb.db = db
+	dn, _ := ldap.ParseDN(baseDN)
+	bdb.base = normalizeDN(dn)
+	return nil
+}
+
+// Initialize() opens the Database file and create the required buckets if they do not
+// exist yet. After calling initialize the database is ready to process transactions
+func (bdb *LdbBolt) Initialize() error {
+	bdb.logger.Debug("Adding default buckets")
+	err := bdb.db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte("dn2id"))
+		if err != nil {
+			return fmt.Errorf("create bucket 'dn2id': %w", err)
+		}
+		_, err = tx.CreateBucketIfNotExists([]byte("id2children"))
+		if err != nil {
+			return fmt.Errorf("create bucket 'dn2id': %w", err)
+		}
+		_, err = tx.CreateBucketIfNotExists([]byte("id2entry"))
+		if err != nil {
+			return fmt.Errorf("create bucket 'id2entry': %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		bdb.logger.WithError(err).Error("Error creating default buckets")
+	}
+	return err
+}
+
+// While formally some RDN attributes could be casesensitive
+// maybe we should just skip the DN parsing and just casefold
+// the entire DN string?
+func normalizeDN(dn *ldap.DN) string {
+	var nDN string
+	caseFold := cases.Fold()
+	for r, rdn := range dn.RDNs {
+		// FIXME to really normalize multivalued RDNs we'd need
+		// to normalize the order of Attributes here as well
+		for a, ava := range rdn.Attributes {
+			if a > 0 {
+				// This is a multivalued RDN.
+				nDN += "+"
+			} else if r > 0 {
+				nDN += ","
+			}
+			nDN = nDN + caseFold.String(ava.Type) + "=" + caseFold.String(ava.Value)
+		}
+	}
+	return nDN
+}
+
+// Performs basic LDAP searches, using the dn2id and id2children buckets to generate
+// a list of Result entries. Currently this does strip of the non-request attribute
+// Neither does it support LDAP filters. For now we rely on the frontent (LDAPServer)
+// to both.
+func (bdb *LdbBolt) Search(base string, scope int) ([]*ldap.Entry, error) {
+	entries := []*ldap.Entry{}
+	dn, _ := ldap.ParseDN(base)
+	nDN := normalizeDN(dn)
+
+	err := bdb.db.View(func(tx *bolt.Tx) error {
+		entryID := bdb.GetIDByDN(tx, nDN)
+		var entryIDs []uint64
+		if entryID == 0 {
+			return fmt.Errorf("not found")
+		}
+		switch scope {
+		case ldap.ScopeBaseObject:
+			entryIDs = append(entryIDs, entryID)
+		case ldap.ScopeSingleLevel:
+			entryIDs = bdb.GetChildrenIDs(tx, entryID)
+		case ldap.ScopeWholeSubtree:
+			entryIDs = append(entryIDs, entryID)
+			entryIDs = append(entryIDs, bdb.GetSubtreeIDs(tx, entryID)...)
+		}
+		id2entry := tx.Bucket([]byte("id2entry"))
+		for _, id := range entryIDs {
+			entrybytes := id2entry.Get(idToBytes(id))
+			buf := bytes.NewBuffer(entrybytes)
+			dec := gob.NewDecoder(buf)
+			var entry ldap.Entry
+			if err := dec.Decode(&entry); err != nil {
+				return fmt.Errorf("error decoding entry id: %d, %w", id, err)
+			}
+			entries = append(entries, &entry)
+		}
+		return nil
+	})
+	return entries, err
+}
+
+func idToBytes(id uint64) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, id)
+	return b
+}
+
+func (bdb *LdbBolt) GetChildrenIDs(tx *bolt.Tx, parent uint64) []uint64 {
+	bdb.logger.Debugf("GetChildrenIDs '%d'", parent)
+	id2Children := tx.Bucket([]byte("id2children"))
+	children := id2Children.Get(idToBytes(parent))
+	r := bytes.NewReader(children)
+	ids := make([]uint64, len(children)/8)
+	if err := binary.Read(r, binary.LittleEndian, &ids); err != nil {
+		bdb.logger.Error(err)
+	}
+	bdb.logger.Debugf("Children '%v'\n", ids)
+	return ids
+}
+
+func (bdb *LdbBolt) GetSubtreeIDs(tx *bolt.Tx, root uint64) []uint64 {
+	bdb.logger.Debugf("GetSubtreeIDs '%d'", root)
+	var res []uint64
+	children := bdb.GetChildrenIDs(tx, root)
+	res = append(res, children...)
+	for _, child := range children {
+		res = append(res, bdb.GetSubtreeIDs(tx, child)...)
+	}
+	bdb.logger.Debugf("GetSubtreeIDs '%v'", res)
+	return res
+}
+
+func (bdb *LdbBolt) EntryPut(e *ldap.Entry) error {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(e); err != nil {
+		fmt.Printf("%v\n", err)
+		panic(err)
+	}
+
+	dn, _ := ldap.ParseDN(e.DN)
+	parentDN := &ldap.DN{
+		RDNs: dn.RDNs[1:],
+	}
+	nDN := normalizeDN(dn)
+
+	if !strings.HasSuffix(nDN, bdb.base) {
+		return fmt.Errorf("'%s' is not a descendant of '%s'", e.DN, bdb.base)
+	}
+
+	nParentDN := normalizeDN(parentDN)
+	err := bdb.db.Update(func(tx *bolt.Tx) error {
+		id2entry := tx.Bucket([]byte("id2entry"))
+		id := bdb.GetIDByDN(tx, nDN)
+		if id == 0 {
+			var err error
+			if id, err = id2entry.NextSequence(); err != nil {
+				return err
+			}
+		}
+
+		if err := id2entry.Put(idToBytes(id), buf.Bytes()); err != nil {
+			return err
+		}
+		if nDN != bdb.base {
+			if err := bdb.AddID2Children(tx, nParentDN, id); err != nil {
+				return err
+			}
+		}
+		dn2id := tx.Bucket([]byte("dn2id"))
+		if err := dn2id.Put([]byte(nDN), idToBytes(id)); err != nil {
+			return err
+		}
+		return nil
+	})
+	return err
+}
+
+func (bdb *LdbBolt) AddID2Children(tx *bolt.Tx, nParentDN string, newChildID uint64) error {
+	bdb.logger.Debugf("AddID2Children '%s' id '%d'", nParentDN, newChildID)
+	parentID := bdb.GetIDByDN(tx, nParentDN)
+	if parentID == 0 {
+		return fmt.Errorf("parent not found '%s'", nParentDN)
+	}
+
+	bdb.logger.Debugf("Parent ID: %v", parentID)
+
+	id2Children := tx.Bucket([]byte("id2children"))
+
+	// FIXME add sanity check here if ID is already present
+	children := id2Children.Get(idToBytes(parentID))
+	children = append(children, idToBytes(newChildID)...)
+	if err := id2Children.Put(idToBytes(parentID), children); err != nil {
+		return fmt.Errorf("error updating id2Children index for %d: %w", parentID, err)
+	}
+
+	bdb.logger.Debugf("AddID2Children '%d' id '%v'", parentID, children)
+	return nil
+}
+
+func (bdb *LdbBolt) GetIDByDN(tx *bolt.Tx, nDN string) uint64 {
+	dn2id := tx.Bucket([]byte("dn2id"))
+	if dn2id == nil {
+		bdb.logger.Debugf("Bucket 'dn2id' does not exist")
+		return 0
+	}
+	id := dn2id.Get([]byte(nDN))
+	if id == nil {
+		bdb.logger.Debugf("DN: '%s' not found", nDN)
+		return 0
+	}
+	return binary.LittleEndian.Uint64(id)
+}
+
+func (bdb *LdbBolt) Close() {
+	bdb.db.Close()
+}

--- a/pkg/ldbbolt/ldbbolt.go
+++ b/pkg/ldbbolt/ldbbolt.go
@@ -49,7 +49,7 @@ func (bdb *LdbBolt) Configure(logger logrus.FieldLogger, baseDN, dbfile string) 
 	}
 	bdb.db = db
 	dn, _ := ldap.ParseDN(baseDN)
-	bdb.base = normalizeDN(dn)
+	bdb.base = NormalizeDN(dn)
 	return nil
 }
 
@@ -81,7 +81,7 @@ func (bdb *LdbBolt) Initialize() error {
 // While formally some RDN attributes could be casesensitive
 // maybe we should just skip the DN parsing and just casefold
 // the entire DN string?
-func normalizeDN(dn *ldap.DN) string {
+func NormalizeDN(dn *ldap.DN) string {
 	var nDN string
 	caseFold := cases.Fold()
 	for r, rdn := range dn.RDNs {
@@ -107,7 +107,7 @@ func normalizeDN(dn *ldap.DN) string {
 func (bdb *LdbBolt) Search(base string, scope int) ([]*ldap.Entry, error) {
 	entries := []*ldap.Entry{}
 	dn, _ := ldap.ParseDN(base)
-	nDN := normalizeDN(dn)
+	nDN := NormalizeDN(dn)
 
 	err := bdb.db.View(func(tx *bolt.Tx) error {
 		entryID := bdb.GetIDByDN(tx, nDN)
@@ -183,13 +183,13 @@ func (bdb *LdbBolt) EntryPut(e *ldap.Entry) error {
 	parentDN := &ldap.DN{
 		RDNs: dn.RDNs[1:],
 	}
-	nDN := normalizeDN(dn)
+	nDN := NormalizeDN(dn)
 
 	if !strings.HasSuffix(nDN, bdb.base) {
 		return fmt.Errorf("'%s' is not a descendant of '%s'", e.DN, bdb.base)
 	}
 
-	nParentDN := normalizeDN(parentDN)
+	nParentDN := NormalizeDN(parentDN)
 	err := bdb.db.Update(func(tx *bolt.Tx) error {
 		id2entry := tx.Bucket([]byte("id2entry"))
 		id := bdb.GetIDByDN(tx, nDN)

--- a/server/config.go
+++ b/server/config.go
@@ -14,6 +14,8 @@ import (
 type Config struct {
 	Logger logrus.FieldLogger
 
+	LDAPHandler string
+
 	LDAPListenAddr  string
 	LDAPSListenAddr string
 

--- a/server/config.go
+++ b/server/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	LDAPBaseDN                  string
 	LDAPAllowLocalAnonymousBind bool
 
+	BoltDBFile string
+
 	LDIFMain   string
 	LDIFConfig string
 

--- a/server/handler/boltdb/handler.go
+++ b/server/handler/boltdb/handler.go
@@ -68,7 +68,7 @@ func NewBoltDBHandler(logger logrus.FieldLogger, fn string, options *Options) (h
 func (h *boltdbHandler) setup() error {
 	bdb := &ldbbolt.LdbBolt{}
 
-	if err := bdb.Configure(h.logger, h.baseDN, h.dbfile); err != nil {
+	if err := bdb.Configure(h.logger, h.baseDN, h.dbfile, nil); err != nil {
 		return err
 	}
 

--- a/server/handler/boltdb/handler.go
+++ b/server/handler/boltdb/handler.go
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2021 The LibreGraph Authors.
+ */
+
+package boltdb
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/sirupsen/logrus"
+
+	"github.com/libregraph/idm/pkg/ldapserver"
+	"github.com/libregraph/idm/pkg/ldbbolt"
+	"github.com/libregraph/idm/server/handler"
+)
+
+type boltdbHandler struct {
+	logger                  logrus.FieldLogger
+	dbfile                  string
+	baseDN                  string
+	allowLocalAnonymousBind bool
+	ctx                     context.Context
+	bdb                     *ldbbolt.LdbBolt
+}
+
+type Options struct {
+	BaseDN                  string
+	AllowLocalAnonymousBind bool
+}
+
+func NewBoltDBHandler(logger logrus.FieldLogger, fn string, options *Options) (handler.Handler, error) {
+	if fn == "" {
+		return nil, fmt.Errorf("file name is empty")
+	}
+	if options.BaseDN == "" {
+		return nil, fmt.Errorf("base dn is empty")
+	}
+
+	fn, err := filepath.Abs(fn)
+	if err != nil {
+		return nil, err
+	}
+	logger = logger.WithField("db", fn)
+
+	h := &boltdbHandler{
+		logger: logger,
+		dbfile: fn,
+
+		baseDN:                  strings.ToLower(options.BaseDN),
+		allowLocalAnonymousBind: options.AllowLocalAnonymousBind,
+		ctx:                     context.Background(),
+	}
+
+	err = h.setup()
+	if err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+func (h *boltdbHandler) setup() error {
+	bdb := &ldbbolt.LdbBolt{}
+
+	if err := bdb.Configure(h.logger, h.baseDN, h.dbfile); err != nil {
+		return err
+	}
+
+	if err := bdb.Initialize(); err != nil {
+		return err
+	}
+	h.bdb = bdb
+	return nil
+}
+
+func (h *boltdbHandler) Bind(bindDN, bindSimplePw string, conn net.Conn) (ldapserver.LDAPResultCode, error) {
+	return ldap.LDAPResultSuccess, nil
+}
+
+func (h *boltdbHandler) Search(boundDN string, req *ldap.SearchRequest, conn net.Conn) (ldapserver.ServerSearchResult, error) {
+	h.logger.WithField("op", "search").Debug("start")
+
+	entries, _ := h.bdb.Search(req.BaseDN, req.Scope)
+
+	return ldapserver.ServerSearchResult{
+		Entries:    entries,
+		Referrals:  []string{},
+		Controls:   []ldap.Control{},
+		ResultCode: ldap.LDAPResultSuccess,
+	}, nil
+}
+
+func (h *boltdbHandler) Close(boundDN string, conn net.Conn) error {
+	return nil
+}
+
+func (h *boltdbHandler) WithContext(ctx context.Context) handler.Handler {
+	if ctx == nil {
+		panic("nil context")
+	}
+
+	h2 := new(boltdbHandler)
+	*h2 = *h
+	h2.ctx = ctx
+	return h2
+}
+
+func (h *boltdbHandler) Reload(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
This adds a new LDAPHandler for retrieving and storing the LDAP tree in a BoltDB based database backend. Currently this Handler only supports search (filtering is still handled in the frontend). It's meant as a starting point to later add write capabilities to libregraph/idm.

Here's a few notes on how to use it:

To create a new database from LDIF:

`idmd db load --ldap-base-dn dc=owncloud,dc=com --input-file users.ldif --boltdb-file ./database.db`

To start the server using the new Handler:

`idmd serve --ldap-base-dn dc=owncloud,dc=com --ldap-handler boltdb --boltdb-file  ./database.db`

To export the database to LDIF on stdout:

`idmd db export --ldap-base-dn dc=owncloud,dc=com --boltdb-file ./database.db`

Some details about the internals of the database can be found here: https://github.com/libregraph/idm/pull/17/commits/337ccc1695c0de133d0205f52a1dad14b7e7f33e#diff-d7ff020510c44751369d6b9907711dee9c1ab104763443f100c8b7bb280dfecdR6
