### PR TITLE
Add TLS support

### DIFF
--- a/pkg/ldapserver/server.go
+++ b/pkg/ldapserver/server.go
@@ -12,7 +12,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/go-asn1-ber/asn1-ber"
+	ber "github.com/go-asn1-ber/asn1-ber"
 	"github.com/go-ldap/ldap/v3"
 )
 
@@ -124,6 +124,7 @@ func (server *Server) Serve(ln net.Listener) error {
 				}
 				break
 			}
+			log.Printf("New Connection on %s", ln.Addr())
 			newConn <- conn
 		}
 	}()

--- a/server/config.go
+++ b/server/config.go
@@ -14,7 +14,11 @@ import (
 type Config struct {
 	Logger logrus.FieldLogger
 
-	LDAPListenAddr string
+	LDAPListenAddr  string
+	LDAPSListenAddr string
+
+	TLSCertFile string
+	TLSKeyFile  string
 
 	LDAPBaseDN                  string
 	LDAPAllowLocalAnonymousBind bool


### PR DESCRIPTION
This adds TLS support (via ldaps) to idmd. Introducing a few new flags to the
`serve` subcommand:

- ldaps-listen: to specify the listen address for TLS requests
- tls-cert-file: to set the server certificate file
- tls-key-file: to set the corresponding key

Closes: #12