### PR TITLE
Adjust golangci-lint config

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,12 +27,11 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.38.0
+        version: latest
         skip-pkg-cache: true
         skip-build-cache: true
         skip-go-installation: true
-        #only-new-issues: true
-        args: --issues-exit-code=0 
+        only-new-issues: true
 
     - name: Build
       run: | 


### PR DESCRIPTION
- Always use latest release
- only report new issues introduces with the PR	being tested
- make test actually fail when issues are found