### PR TITLE
Don't consider linter failures fatal

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,6 @@
 run:
   modules-download-mode: vendor
+  issues-exit-code: 0
 
 linters-settings:
   govet:


### PR DESCRIPTION
Have the linter create the annotations on the PRs but don't consider
linting issues CI failures.

Fixes: #21