### PR TITLE
Introduce new parameter "ldap-admin-dn" 

### DIFF
--- a/cmd/idmd/serve/serve.go
+++ b/cmd/idmd/serve/serve.go
@@ -37,7 +37,9 @@ var (
 	DefaultTLSCertFile = ""
 	DefaultTLSKeyFile  = ""
 
-	DefaultLDAPBaseDN                  = ""
+	DefaultLDAPBaseDN  = ""
+	DefaultLDAPAdminDN = ""
+
 	DefaultLDAPAllowLocalAnonymousBind = false
 
 	DefaultBoltDBFile = "idmbolt.db"
@@ -72,9 +74,15 @@ func setDefaults() {
 	if envDefaultBoltDBFile != "" {
 		DefaultBoltDBFile = envDefaultBoltDBFile
 	}
+
 	envDefaultLDAPBaseDN := os.Getenv(withEnvBase("DEFAULT_LDAP_BASEDN"))
 	if envDefaultLDAPBaseDN != "" {
 		DefaultLDAPBaseDN = envDefaultLDAPBaseDN
+	}
+
+	envDefaultLDAPAdminDN := os.Getenv(withEnvBase("DEFAULT_LDAP_ADMINDN"))
+	if envDefaultLDAPAdminDN != "" {
+		DefaultLDAPAdminDN = envDefaultLDAPAdminDN
 	}
 
 	envDefaultLDAPListenAddr := os.Getenv(withEnvBase("DEFAULT_LDAP_LISTEN"))
@@ -154,6 +162,9 @@ func CommandServe() *cobra.Command {
 	serveCmd.Flags().StringVar(&DefaultTLSKeyFile, "tls-key-file", DefaultTLSKeyFile, "Server Certificate Key to use for LDAPS connections")
 
 	serveCmd.Flags().StringVar(&DefaultLDAPBaseDN, "ldap-base-dn", DefaultLDAPBaseDN, "BaseDN for LDAP requests")
+	serveCmd.Flags().StringVar(&DefaultLDAPAdminDN, "ldap-admin-dn",
+		DefaultLDAPAdminDN, "Administrator DN. This DN is given full write access to the directory. For Handlers that support write")
+
 	serveCmd.Flags().BoolVar(&DefaultLDAPAllowLocalAnonymousBind, "ldap-allow-local-anonymous", DefaultLDAPAllowLocalAnonymousBind, "Allow anonymous LDAP bind for all local LDAP clients")
 
 	serveCmd.Flags().StringVar(&DefaultBoltDBFile, "boltdb-file", DefaultBoltDBFile, "Filename of the database for the BoltDB Handler")
@@ -225,7 +236,9 @@ func (bs *bootstrap) configure(ctx context.Context, cmd *cobra.Command, args []s
 		TLSCertFile: DefaultTLSCertFile,
 		TLSKeyFile:  DefaultTLSKeyFile,
 
-		LDAPBaseDN:                  DefaultLDAPBaseDN,
+		LDAPBaseDN:  DefaultLDAPBaseDN,
+		LDAPAdminDN: DefaultLDAPAdminDN,
+
 		LDAPAllowLocalAnonymousBind: DefaultLDAPAllowLocalAnonymousBind,
 
 		LDIFMain:   DefaultLDIFMain,

--- a/pkg/ldapserver/server.go
+++ b/pkg/ldapserver/server.go
@@ -15,6 +15,7 @@ import (
 
 	ber "github.com/go-asn1-ber/asn1-ber"
 	"github.com/go-ldap/ldap/v3"
+	"github.com/libregraph/idm/pkg/ldapdn"
 )
 
 type Adder interface {
@@ -265,9 +266,14 @@ handler:
 			if ldapResultCode == ldap.LDAPResultSuccess {
 				boundDN, ok = req.Children[1].Value.(string)
 				if !ok {
-					log.Printf("Malformed Bind DN")
+					log.Print("Malformed Bind DN")
 					break handler
 				}
+				if boundDN, err = ldapdn.ParseNormalize(boundDN); err != nil {
+					log.Printf("Error normalizing Bind DN: %s", err)
+					break handler
+				}
+
 			}
 			responsePacket := encodeBindResponse(messageID, ldapResultCode)
 			if err = sendPacket(conn, responsePacket); err != nil {

--- a/server/config.go
+++ b/server/config.go
@@ -22,7 +22,9 @@ type Config struct {
 	TLSCertFile string
 	TLSKeyFile  string
 
-	LDAPBaseDN                  string
+	LDAPBaseDN  string
+	LDAPAdminDN string
+
 	LDAPAllowLocalAnonymousBind bool
 
 	BoltDBFile string

--- a/server/handler/boltdb/handler.go
+++ b/server/handler/boltdb/handler.go
@@ -56,9 +56,11 @@ func NewBoltDBHandler(logger logrus.FieldLogger, fn string, options *Options) (h
 		logger: logger,
 		dbfile: fn,
 
-		baseDN:                  strings.ToLower(options.BaseDN),
 		allowLocalAnonymousBind: options.AllowLocalAnonymousBind,
 		ctx:                     context.Background(),
+	}
+	if h.baseDN, err = ldapdn.ParseNormalize(options.BaseDN); err != nil {
+		return nil, err
 	}
 
 	err = h.setup()

--- a/server/handler/ldif/handler.go
+++ b/server/handler/ldif/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"stash.kopano.io/kgol/rndm"
 
+	"github.com/libregraph/idm/pkg/ldapdn"
 	"github.com/libregraph/idm/pkg/ldapserver"
 	"github.com/libregraph/idm/server/handler"
 )
@@ -63,12 +64,14 @@ func NewLDIFHandler(logger logrus.FieldLogger, fn string, options *Options) (han
 		fn:      fn,
 		options: options,
 
-		baseDN:                  strings.ToLower(options.BaseDN),
 		allowLocalAnonymousBind: options.AllowLocalAnonymousBind,
 
 		ctx: context.Background(),
 
 		activeSearchPagings: cmap.New(),
+	}
+	if h.baseDN, err = ldapdn.ParseNormalize(options.BaseDN); err != nil {
+		return nil, err
 	}
 
 	err = h.open()

--- a/server/handler/ldif/handler.go
+++ b/server/handler/ldif/handler.go
@@ -34,6 +34,7 @@ type ldifHandler struct {
 	options *Options
 
 	baseDN                  string
+	adminDN                 string
 	allowLocalAnonymousBind bool
 
 	ctx context.Context
@@ -71,6 +72,9 @@ func NewLDIFHandler(logger logrus.FieldLogger, fn string, options *Options) (han
 		activeSearchPagings: cmap.New(),
 	}
 	if h.baseDN, err = ldapdn.ParseNormalize(options.BaseDN); err != nil {
+		return nil, err
+	}
+	if h.adminDN, err = ldapdn.ParseNormalize(options.AdminDN); err != nil {
 		return nil, err
 	}
 

--- a/server/handler/ldif/options.go
+++ b/server/handler/ldif/options.go
@@ -7,6 +7,7 @@ package ldif
 
 type Options struct {
 	BaseDN                  string
+	AdminDN                 string
 	AllowLocalAnonymousBind bool
 
 	DefaultCompany    string

--- a/server/server.go
+++ b/server/server.go
@@ -49,6 +49,7 @@ func NewServer(c *Config) (*Server, error) {
 	case "ldif":
 		ldifHandlerOptions := &ldif.Options{
 			BaseDN:                  s.config.LDAPBaseDN,
+			AdminDN:                 s.config.LDAPAdminDN,
 			AllowLocalAnonymousBind: s.config.LDAPAllowLocalAnonymousBind,
 
 			DefaultCompany:    s.config.LDIFDefaultCompany,
@@ -71,7 +72,9 @@ func NewServer(c *Config) (*Server, error) {
 		}
 	case "boltdb":
 		boltOptions := &boltdb.Options{
-			BaseDN:                  s.config.LDAPBaseDN,
+			BaseDN:  s.config.LDAPBaseDN,
+			AdminDN: s.config.LDAPAdminDN,
+
 			AllowLocalAnonymousBind: s.config.LDAPAllowLocalAnonymousBind,
 		}
 		s.LDAPHandler, err = boltdb.NewBoltDBHandler(s.logger, s.config.BoltDBFile, boltOptions)


### PR DESCRIPTION
We want to restrict LDAP Updates to a single (super-)user. The new
commandline parameter defines the DN that is given write access to the
full database. All other users will have read-only access.