### PR TITLE
Drop "userPassword" from Search Results

### DIFF
--- a/pkg/ldapentry/ldapentry.go
+++ b/pkg/ldapentry/ldapentry.go
@@ -3,6 +3,7 @@ package ldapentry
 import (
 	"errors"
 	"log"
+	"strings"
 
 	"github.com/go-ldap/ldap/v3"
 	"golang.org/x/text/cases"
@@ -129,6 +130,19 @@ func entryApplyModDelete(curVals, delVals []string) (newVals []string) {
 		}
 	}
 	return newVals
+}
+
+func EntryDropAttribute(e *ldap.Entry, at string) *ldap.Entry {
+	if len(e.GetEqualFoldAttributeValues(at)) == 0 {
+		return e
+	}
+	var newAttr []*ldap.EntryAttribute
+	for _, attr := range e.Attributes {
+		if !strings.EqualFold(at, attr.Name) {
+			newAttr = append(newAttr, attr)
+		}
+	}
+	return &ldap.Entry{DN: e.DN, Attributes: newAttr}
 }
 
 func EntryFromAddRequest(add *ldap.AddRequest) *ldap.Entry {

--- a/pkg/ldapentry/ldapentry_test.go
+++ b/pkg/ldapentry/ldapentry_test.go
@@ -128,3 +128,17 @@ func TestApplyModifyReplace(t *testing.T) {
 		t.Errorf("Replace attribute value failed")
 	}
 }
+
+func TestDropEntryAttribute(t *testing.T) {
+	e := EntryDropAttribute(userEntry, "displayName")
+	if len(e.GetEqualFoldAttributeValues("displayName")) != 0 {
+		t.Errorf("Attribute does still exist after delete")
+	}
+	e = EntryDropAttribute(userEntry, "doesnotexist")
+	if len(e.GetEqualFoldAttributeValues("doesnotexist")) != 0 {
+		t.Errorf("Dropping non existing Attribute failed")
+	}
+	if len(e.GetEqualFoldAttributeValues("displayName")) != 1 {
+		t.Errorf("Dropping non existing Attribute failed")
+	}
+}

--- a/server/handler/boltdb/handler.go
+++ b/server/handler/boltdb/handler.go
@@ -207,8 +207,15 @@ func (h *boltdbHandler) Search(boundDN string, req *ldap.SearchRequest, conn net
 
 	entries, _ := h.bdb.Search(req.BaseDN, req.Scope)
 
+	// strip "userPassword" Attribute from the Results
+	var sr []*ldap.Entry
+	for _, e := range entries {
+		entry := ldapentry.EntryDropAttribute(e, "userPassword")
+		sr = append(sr, entry)
+	}
+
 	return ldapserver.ServerSearchResult{
-		Entries:    entries,
+		Entries:    sr,
 		Referrals:  []string{},
 		Controls:   []ldap.Control{},
 		ResultCode: ldap.LDAPResultSuccess,


### PR DESCRIPTION
Let's not expose the password hashes to clients.