### PR TITLE
Allow to disable go-crypt related code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ PKGS     = $(or $(PKG),$(shell $(GO) list -mod=readonly ./... | grep -v "^$(PACK
 TESTPKGS = $(shell $(GO) list -mod=readonly -f '{{ if or .TestGoFiles .XTestGoFiles }}{{ .ImportPath }}{{ end }}' $(PKGS) 2>/dev/null)
 CMDS     = $(or $(CMD),$(addprefix cmd/,$(notdir $(shell find "$(PWD)/cmd/" -maxdepth 1 -type d))))
 TIMEOUT  = 30
+BUILD_TAGS ?=
 
 # Build
 
@@ -47,7 +48,7 @@ $(CMDS): vendor ; $(info building $@ ...) @
 	CGO_ENABLED=$(CGO_ENABLED) $(GO) build \
 		-mod=vendor \
 		-trimpath \
-		-tags release \
+		-tags "release $(BUILD_TAGS)" \
 		-buildmode=exe \
 		-ldflags '-s -w -buildid=reproducible/$(VERSION) -X $(PACKAGE)/version.Version=$(VERSION) -X $(PACKAGE)/version.BuildDate=$(DATE) -extldflags -static' \
 		-o bin/$(notdir $@) ./$@

--- a/pkg/ldappassword/crypt.go
+++ b/pkg/ldappassword/crypt.go
@@ -1,4 +1,4 @@
-//go:build linux || freebsd || netbsd
+//go:build !disable_crypt && (linux || freebsd || netbsd)
 
 /*
  * SPDX-License-Identifier: Apache-2.0

--- a/pkg/ldappassword/crypt_disabled.go
+++ b/pkg/ldappassword/crypt_disabled.go
@@ -1,3 +1,5 @@
+//go:build disable_crypt || darwin || windows
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  * Copyright 2021 The LibreGraph Authors.


### PR DESCRIPTION
Introduce a buildflag `disable_crypt` to allow to build without the
go-crypt dependency (e.g. when running on platforms with unsuitable libc
implementations)

Fixes #49