### PR TITLE
pass through unparsed DN

### DIFF
--- a/pkg/ldapentry/ldapentry.go
+++ b/pkg/ldapentry/ldapentry.go
@@ -6,23 +6,20 @@ import (
 
 	"github.com/go-ldap/ldap/v3"
 	"golang.org/x/text/cases"
-
-	"github.com/libregraph/idm/pkg/ldapdn"
 )
 
 func ApplyModify(old *ldap.Entry, mod *ldap.ModifyRequest) (newEntry *ldap.Entry, err error) {
-	parsed, err := ldap.ParseDN(old.DN)
+	oldDN, err := ldap.ParseDN(old.DN)
 	if err != nil {
 		return nil, err
 	}
-	nOldDN := ldapdn.Normalize(parsed)
-	rdn := parsed.RDNs[0]
-	nReqDN, err := ldapdn.ParseNormalize(mod.DN)
+	rdn := oldDN.RDNs[0]
+	modDN, err := ldap.ParseDN(mod.DN)
 	if err != nil {
 		return nil, err
 	}
 	// This shouldn't happen if we ge here (TM)
-	if nOldDN != nReqDN {
+	if oldDN.EqualFold(modDN) {
 		return nil, ldap.NewError(ldap.LDAPResultUnwillingToPerform, errors.New("DNs do not match"))
 	}
 

--- a/pkg/ldbbolt/ldbbolt.go
+++ b/pkg/ldbbolt/ldbbolt.go
@@ -343,7 +343,7 @@ func (bdb *LdbBolt) UpdatePassword(req *ldap.PasswordModifyRequest) error {
 		}
 
 		mod := ldap.ModifyRequest{}
-		mod.DN = ndn
+		mod.DN = req.UserIdentity
 		mod.Replace("userPassword", []string{req.NewPassword})
 		innerErr = bdb.entryModifyWithTxn(tx, id, userEntry, &mod)
 		if innerErr != nil {


### PR DESCRIPTION
The DN will be parsed in a subsequent step and when passing the parsed DN it could contain special characters in un-escaped format, which would result in the failure to parse the DN. Instead we pass it as we got it so that the special characters remain escaped.

E.g.: `req.UserIdentity = "uid=c0rby\+,..."` after parsing the `ndn = "uid=c0rby+,..."` Now if we would try to parse it again it would fail because of the plus sign.