### PR TITLE
Switch github action to use `make test`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,7 +39,7 @@ jobs:
         ./bin/idmd version && sha256sum ./bin/idmd
 
     - name: Test
-      run: make test-xml-short
+      run: make test
 
     - name: Dist
       run: |

--- a/pkg/ldapentry/ldapentry.go
+++ b/pkg/ldapentry/ldapentry.go
@@ -19,7 +19,7 @@ func ApplyModify(old *ldap.Entry, mod *ldap.ModifyRequest) (newEntry *ldap.Entry
 		return nil, err
 	}
 	// This shouldn't happen if we ge here (TM)
-	if oldDN.EqualFold(modDN) {
+	if !oldDN.EqualFold(modDN) {
 		return nil, ldap.NewError(ldap.LDAPResultUnwillingToPerform, errors.New("DNs do not match"))
 	}
 


### PR DESCRIPTION
The `make test-xml-short` target does not seem to correcty
exit with a non-zero value when the test suite fails (also
the test enviroment seems to lack the go2xunit tool)