### PR TITLE
Fix normalized DN attribute escaping

### DIFF
--- a/pkg/ldapdn/ldapdn_test.go
+++ b/pkg/ldapdn/ldapdn_test.go
@@ -1,0 +1,24 @@
+package ldapdn
+
+import (
+	"testing"
+)
+
+func TestParseNormalize(t *testing.T) {
+	tests := map[string]string{
+		"uid=Test,ou=test":            "uid=test,ou=test",
+		"uid=rDN1+cn=rDN2,ou=test":    "uid=rdn1+cn=rdn2,ou=test",
+		"uid=Test\\+withplus,ou=test": "uid=test\\+withplus,ou=test",
+		"uid=Test\\2bTest,ou=test":    "uid=test\\+test,ou=test",
+		"uid=Test\\00test,ou=teSt":    "uid=test\\00test,ou=test",
+	}
+
+	for in, out := range tests {
+		res, err := ParseNormalize(in)
+		if err != nil {
+			t.Errorf("Unexpected err: %s", err)
+		} else if res != out {
+			t.Errorf("Expected %s got %s", out, res)
+		}
+	}
+}


### PR DESCRIPTION
Apply the DN escaping rules on the normalized DN parts when
turning a DN into a normalized string form

Fixes: #70