### PR TITLE
Fix ModifyDN operation in boltdb backend

### DIFF
--- a/pkg/ldapserver/server.go
+++ b/pkg/ldapserver/server.go
@@ -382,9 +382,8 @@ handler:
 			responsePacket := encodeLDAPResponse(messageID, ldap.ApplicationModifyDNResponse, LDAPResultCode(resultCode), resultMsg)
 			if err = sendPacket(conn, responsePacket); err != nil {
 				logger.Error(err, "sendPacket error")
+				break handler
 			}
-			logger.V(1).Info("Unhandled operation", "type", ldap.ApplicationMap[uint8(req.Tag)], "tag", req.Tag)
-			break handler
 
 		case ldap.ApplicationModifyRequest:
 			server.Stats.countModifies(1)

--- a/pkg/ldbbolt/ldbbolt.go
+++ b/pkg/ldbbolt/ldbbolt.go
@@ -331,15 +331,14 @@ func (bdb *LdbBolt) EntryModifyDN(req *ldap.ModifyDNRequest) error {
 		flatNewDN := ldapdn.Normalize(&newDN)
 		flatOldDN := ldapdn.Normalize(olddn)
 
+		// error out if there is an entry with the new name already
+		if id := bdb.getIDByDN(tx, flatNewDN); id != 0 {
+			return ErrEntryAlreadyExists
+		}
+
 		entry, id, innerErr := bdb.getEntryByDN(tx, flatOldDN)
 		if innerErr != nil {
 			return innerErr
-		}
-
-		// error out if there is an entry with the new name already
-		id = bdb.getIDByDN(tx, flatNewDN)
-		if id != 0 {
-			return ErrEntryAlreadyExists
 		}
 
 		// only allow renaming leaf entries


### PR DESCRIPTION
Update the correct entry in the dn2id bucket with the new DN (was using the wrong id previously).

Also fixes the response to not return an error all the time.